### PR TITLE
生死判定＆オーバーキルでHPを負にしない処理を追加

### DIFF
--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -34,6 +34,8 @@ class Creature < ApplicationRecord
   alias_attribute :さいだいMP, :max_concentration_power
 
   validates :なまえ, presence: true
+  validates :HP, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: :さいだいHP }
+  validates :MP, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: :さいだいMP }
 
   def こうげき力
     ちから

--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -37,6 +37,19 @@ class Creature < ApplicationRecord
   validates :HP, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: :さいだいHP }
   validates :MP, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: :さいだいMP }
 
+  def いてっ！(other)
+    予測HP = self.HP - other
+    self.HP = 予測HP <= 0 ? 0 : 予測HP
+  end
+
+  def いきてる？
+    !しぼんぬ？
+  end
+
+  def しぼんぬ？
+    self.HP.zero?
+  end
+
   def こうげき力
     ちから
   end

--- a/app/services/attack_service.rb
+++ b/app/services/attack_service.rb
@@ -3,7 +3,9 @@ class AttackService < BaseService
   attr_accessor :する子, :される子
 
   def call
-    ぬわーーっっ！！
+    return unless する子.いきてる？ && される子.いきてる？
+
+    ダメージをくらわす
   end
 
   def initialize(する子, される子)
@@ -22,13 +24,13 @@ class AttackService < BaseService
     与ダメ.positive? ? 与ダメ : 0
   end
 
-  def ぬわーーっっ！！
+  def ダメージをくらわす
     メッセージ出力 "#{する子.なまえ}の こうげき！"
     if 与えるダメージ.zero?
       メッセージ出力 "#{される子.なまえ}に ダメージを あたえられない！"
     else
       メッセージ出力 "#{される子.なまえ}に #{与えるダメージ}の ダメージ！！"
     end
-    される子.HP = される子.HP - 与えるダメージ
+    される子.いてっ！ 与えるダメージ
   end
 end

--- a/app/services/battle_simulation_service.rb
+++ b/app/services/battle_simulation_service.rb
@@ -40,6 +40,6 @@ class BattleSimulationService < BaseService
   end
 
   def みなさん
-    (パーティーメンバー + モンスターの群れ)
+    パーティーメンバー + モンスターの群れ
   end
 end

--- a/app/services/battle_simulation_service.rb
+++ b/app/services/battle_simulation_service.rb
@@ -24,7 +24,11 @@ class BattleSimulationService < BaseService
   end
 
   def すばやさ降順でソート
-    みなさん.sort_by(&:すばやさ).reverse
+    いきてるみなさん.sort_by(&:すばやさ).reverse
+  end
+
+  def いきてるみなさん
+    みなさん.select(&:いきてる？)
   end
 
   def こうげき(する子, される子)

--- a/spec/factories/adventurer.rb
+++ b/spec/factories/adventurer.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :adventurer do
     なまえ { 'トンヌラ' }
+    HP { 256 }
+    MP { 128 }
+    さいだいHP { 256 }
+    さいだいMP { 128 }
   end
 end

--- a/spec/factories/monster.rb
+++ b/spec/factories/monster.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :monster do
     name { 'スライム' }
+    HP { 512 }
+    MP { 384 }
+    さいだいHP { 512 }
+    さいだいMP { 384 }
   end
 end

--- a/spec/models/creature_spec.rb
+++ b/spec/models/creature_spec.rb
@@ -23,6 +23,38 @@
 
 require 'rails_helper'
 
-RSpec.describe Creature, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe Creature, type: :model, issue: '#3' do
+  let(:サンチョ) { create(:adventurer, HP: 50, さいだいHP: 50) }
+
+  describe '#いてっ！' do
+    it { expect { サンチョ.いてっ！(30) }.to change(サンチョ, :HP).from(50).to(20) }
+
+    context '坊ちゃんからオーバーキル' do
+      before { サンチョ.いてっ！(9999) }
+
+      it 'HPは0' do
+        expect(サンチョ.HP).to eq 0
+      end
+    end
+  end
+
+  describe '#いきてる？' do
+    it { expect(サンチョ.いきてる？).to eq true }
+
+    context 'HP == 0' do
+      before { サンチョ.HP = 0 }
+
+      it { expect(サンチョ.いきてる？).to eq false }
+    end
+  end
+
+  describe '#しぼんぬ？' do
+    it { expect(サンチョ.しぼんぬ？).to eq false }
+
+    context 'HP == 0' do
+      before { サンチョ.HP = 0 }
+
+      it { expect(サンチョ.しぼんぬ？).to eq true }
+    end
+  end
 end

--- a/spec/support/shared_context_model.rb
+++ b/spec/support/shared_context_model.rb
@@ -1,11 +1,4 @@
 RSpec.shared_examples '基本パラメータ' do
-  describe 'validates' do
-    it 'なまえは必須' do
-      生き物.なまえ = ''
-      expect(生き物.valid?).to eq false
-    end
-  end
-
   describe '#こうげき力' do
     before { 生き物.ちから = 60 }
 
@@ -19,6 +12,74 @@ RSpec.shared_examples '基本パラメータ' do
 
     it 'みのまもりと同じ' do
       expect(生き物.しゅび力).to eq 55
+    end
+  end
+
+  describe 'validates' do
+    context 'なまえ == ""' do
+      before { 生き物.なまえ = '' }
+
+      it { expect(生き物.valid?).to eq false }
+    end
+
+    context 'HP == 0', issue: '#3' do
+      before { 生き物.HP = 0 }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'HP == 0.1', issue: '#3' do
+      before { 生き物.HP = 0.1 }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'HP == さいだいHP', issue: '#3' do
+      before { 生き物.HP = 生き物.さいだいHP }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'HP > さいだいHP', issue: '#3' do
+      before { 生き物.HP = 生き物.さいだいHP + 1 }
+
+      it { expect(生き物.valid?).to eq false }
+    end
+
+    context 'HP == -1', issue: '#3' do
+      before { 生き物.HP = -1 }
+
+      it { expect(生き物.valid?).to eq false }
+    end
+
+    context 'MP == 0', issue: '#3' do
+      before { 生き物.MP = 0 }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'MP == 0.1', issue: '#3' do
+      before { 生き物.MP = 0.1 }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'MP == さいだいMP', issue: '#3' do
+      before { 生き物.MP = 生き物.さいだいMP }
+
+      it { expect(生き物.valid?).to eq true }
+    end
+
+    context 'MP > さいだいMP', issue: '#3' do
+      before { 生き物.MP = 生き物.さいだいMP + 1 }
+
+      it { expect(生き物.valid?).to eq false }
+    end
+
+    context 'MP == -1', issue: '#3' do
+      before { 生き物.MP = -1 }
+
+      it { expect(生き物.valid?).to eq false }
     end
   end
 end


### PR DESCRIPTION
# 課題
#3 

## テスト

```bash
$ bin/rspec -fd -t issue:#3

Adventurer
  基本パラメータ
    behaves like 基本パラメータ
      validates
        HP > さいだいHP
          should eq false
        MP == -1
          should eq false
        HP == 0
          should eq true
        MP == 0
          should eq true
        MP == さいだいMP
          should eq true
        MP > さいだいMP
          should eq false
        HP == 0.1
          should eq true
        MP == 0.1
          should eq true
        HP == さいだいHP
          should eq true
        HP == -1
          should eq false

Monster
  基本パラメータ
    behaves like 基本パラメータ
      validates
        HP == -1
          should eq false
        MP == 0
          should eq true
        HP == 0
          should eq true
        HP == さいだいHP
          should eq true
        MP == -1
          should eq false
        HP > さいだいHP
          should eq false
        HP == 0.1
          should eq true
        MP == 0.1
          should eq true
        MP == さいだいMP
          should eq true
        MP > さいだいMP
          should eq false

Creature
  #いてっ！
    should change `Adventurer#HP` from 50 to 20
    坊ちゃんからオーバーキル
      HPは0
  #しぼんぬ？
    should eq false
    HP == 0
      should eq true
  #いきてる？
    should eq true
    HP == 0
      should eq false

Finished in 0.1866 seconds (files took 0.59866 seconds to load)
26 examples, 0 failures
```
